### PR TITLE
v28.0

### DIFF
--- a/scripts/mods/TourneyBalance/changes/career_changes.lua
+++ b/scripts/mods/TourneyBalance/changes/career_changes.lua
@@ -147,11 +147,6 @@ mod:add_buff_function("activate_party_buff_stacks_on_ally_proximity", function (
 	end
 end)
 
-mod:modify_talent_buff_template("empire_soldier", "markus_knight_damage_taken_ally_proximity_buff", {
-	multiplier = -0.033
-})
-mod:add_text("markus_knight_damage_taken_ally_proximity_desc_2", "Increases damage protection from Protective Presence by 3.33%% for each nearby ally")
-
 --[[
 
 	Ranger Veteran
@@ -198,6 +193,34 @@ ActivatedAbilitySettings.es_1[1].cooldown = 75
 ]]
 -- Made Widecharge the standard Footknight ult
 ActivatedAbilitySettings.es_2[1].cooldown = 40
+
+-- baseline ult buff
+mod:hook(CareerAbilityESKnight, "_run_ability", function (func, self, ...)
+	func(self, ...)
+
+    local owner_unit = self._owner_unit
+    local talent_extension = ScriptUnit.extension(owner_unit, "talent_system")
+	local status_extension = self._status_extension
+
+	-- increase radius of explosion and double cleave of explosion and normal charge
+	status_extension.do_lunge.damage.on_interrupt_blast.radius = 4 --3
+	PowerLevelTemplates.cleave_distribution_markus_knight_charge = {
+		attack = 4, --2 
+		impact = 4, --2
+	}
+
+	if talent_extension:has_talent("markus_knight_wide_charge", "empire_soldier", true) then
+		-- remove buffs from baseline ult if battering ram is selected
+		PowerLevelTemplates.cleave_distribution_markus_knight_charge = {
+			attack = 2,
+			impact = 2,
+		}
+		status_extension.do_lunge.damage.on_interrupt_blast.radius = 3 --3 --remove buff from baseline for battering ram specifically
+		status_extension.do_lunge.damage.width = 5
+		status_extension.do_lunge.damage.interrupt_on_max_hit_mass = false
+	end
+
+end)
 
 
 --[[
@@ -252,6 +275,27 @@ mod:modify_talent_buff_template("dwarf_ranger", "bardin_ranger_activated_ability
 	max_stacks = 1
 })
 mod:add_text("bardin_ranger_activated_ability_stealth_outside_of_smoke_desc", "Disengage's stealth does not break on moving beyond the smoke cloud. Reduces the cooldown of Disengage by 30%")
+
+--[[
+
+	Iron Breaker
+
+]]
+-- reduce Impenetrable from 50% DR to 28.5% Damage reduction
+mod:modify_talent_buff_template("dwarf_ranger", "bardin_ironbreaker_activated_ability", {
+	{
+		stat_buff = "damage_taken",
+		multiplier = -0.285
+	},
+})
+mod:modify_talent_buff_template("dwarf_ranger", "bardin_ironbreaker_activated_ability_taunt_range_and_duration", {
+	{
+		stat_buff = "damage_taken",
+		multiplier = -0.285
+	},
+})
+mod:add_text("career_active_desc_dr_1", "Bardin taunts all nearby man-sized enemies, takes 28.5% less damage (stacks with Dwarf-Forged) and has 0 block cost for the next 10 seconds")
+
 
 --[[
 	

--- a/scripts/mods/TourneyBalance/changes/talent_changes.lua
+++ b/scripts/mods/TourneyBalance/changes/talent_changes.lua
@@ -931,9 +931,6 @@ mod:add_proc_function("gs_add_bardin_slayer_passive_buff", function(owner_unit, 
 		end
 	end
 end)
-mod:modify_talent_buff_template("dwarf_ranger", "bardin_slayer_passive_stacking_damage_buff_on_hit", {
-	buff_func = "gs_add_bardin_slayer_passive_buff"
-})
 mod:add_talent_buff_template("dwarf_ranger", "gs_bardin_slayer_passive_movement_speed_extra", {
 	max_stacks = 4,
 	multiplier = 1.1,

--- a/scripts/mods/TourneyBalance/changes/weapon_changes.lua
+++ b/scripts/mods/TourneyBalance/changes/weapon_changes.lua
@@ -3352,12 +3352,10 @@ Weapons.dual_wield_axe_falchion_template.actions.action_one.light_attack_bopp.hi
 Weapons.one_handed_crowbill.actions.action_one.heavy_attack.damage_profile = "crowbill_heavy_1"
 Weapons.one_handed_crowbill.actions.action_one.heavy_attack_left.damage_profile = "crowbill_heavy_2"
 Weapons.one_handed_crowbill.actions.action_one.heavy_attack_right_up.damage_profile = "crowbill_heavy_3"
-
 Weapons.one_handed_crowbill.actions.action_one.light_attack_last.damage_profile = "crowbill_light_1"
 Weapons.one_handed_crowbill.actions.action_one.light_attack_upper.damage_profile = "crowbill_light_2"
 Weapons.one_handed_crowbill.actions.action_one.light_attack_right.damage_profile = "crowbill_light_3"
 Weapons.one_handed_crowbill.actions.action_one.light_attack_left.damage_profile = "crowbill_light_4"
-
 Weapons.one_handed_crowbill.actions.action_one.light_attack_bopp.damage_profile = "crowbill_push_attack"
 Weapons.one_handed_crowbill.actions.action_one.light_attack_bopp.additional_critical_strike_chance = 0.05
 
@@ -3699,7 +3697,7 @@ NewDamageProfileTemplates.crowbill_light_1 = {
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.165,
-				impact = 0.91,
+				impact = 0.091,
 			},
 		},
 		{	
@@ -3708,7 +3706,7 @@ NewDamageProfileTemplates.crowbill_light_1 = {
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.12,
-				impact = 0.82,
+				impact = 0.082,
 			},
 		},
 	},
@@ -3774,7 +3772,7 @@ NewDamageProfileTemplates.crowbill_light_2 = { -- Needs to do more damage than L
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.211, -- 0.175
-				impact = 0.95,
+				impact = 0.095,
 			},
 		},
 		{	
@@ -3783,7 +3781,7 @@ NewDamageProfileTemplates.crowbill_light_2 = { -- Needs to do more damage than L
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.177, -- 0.175
-				impact = 0.9,
+				impact = 0.09,
 			},
 		},
 		{	
@@ -3792,7 +3790,7 @@ NewDamageProfileTemplates.crowbill_light_2 = { -- Needs to do more damage than L
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.143, -- 0.175
-				impact = 0.85,
+				impact = 0.085,
 			},
 		},
 		{	
@@ -3801,7 +3799,7 @@ NewDamageProfileTemplates.crowbill_light_2 = { -- Needs to do more damage than L
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.109, -- 0.175
-				impact = 0.8,
+				impact = 0.08,
 			},
 		},
 	},
@@ -3865,7 +3863,7 @@ NewDamageProfileTemplates.crowbill_light_3 = {
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.21, -- 0.175, 0.237
-				impact = 0.94,
+				impact = 0.094,
 			},
 		},
 		{	
@@ -3874,7 +3872,7 @@ NewDamageProfileTemplates.crowbill_light_3 = {
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.165, -- 0.175, 0.237
-				impact = 0.87,
+				impact = 0.087,
 			},
 		},
 		{	
@@ -3883,7 +3881,7 @@ NewDamageProfileTemplates.crowbill_light_3 = {
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.120, -- 0.175, 0.237
-				impact = 0.81,
+				impact = 0.081,
 			},
 		},
 	}
@@ -4004,7 +4002,7 @@ NewDamageProfileTemplates.crowbill_push_attack = { -- 5% crit chance to give thi
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.15,
-				impact = 0.94,
+				impact = 0.094,
 			},
 		},
 		{
@@ -4013,7 +4011,7 @@ NewDamageProfileTemplates.crowbill_push_attack = { -- 5% crit chance to give thi
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.125,
-				impact = 0.88,
+				impact = 0.088,
 			},
 		},
 		{
@@ -4022,11 +4020,12 @@ NewDamageProfileTemplates.crowbill_push_attack = { -- 5% crit chance to give thi
 			boost_curve_type = "ninja_curve",
 			power_distribution = {
 				attack = 0.1,
-				impact = 0.82,
+				impact = 0.082,
 			},
 		},
 	}
 }
+
 
 
 --Scythe


### PR DESCRIPTION
- Nerfed Iron Breaker Ultimate Damage Reduction from 50% to 28.5%
- Buffed Footknight base ult cleave by 100% and explosion radius from 3 to 4 units
- Reverted / Buffed Footknight Bloody Teamwork to 5% from 3.33%
- Fixed Slayer Trophy Hunter
- Fixed minor crowbill numbers