### PR TITLE
v29.1

### DIFF
--- a/scripts/mods/TourneyBalance/changes/career_changes.lua
+++ b/scripts/mods/TourneyBalance/changes/career_changes.lua
@@ -986,7 +986,7 @@ mod:hook_origin(GenericStatusExtension, "blocked_attack", function (self, fatigu
 			blocking_unit = equipment.right_hand_wielded_unit_3p or equipment.left_hand_wielded_unit_3p
 
 			QuestSettings.handle_bastard_block(unit, attacking_unit, true)
-			self:add_fatigue_points(fatigue_type, attacking_unit, blocking_unit, fatigue_point_costs_multiplier, is_timed_block)
+			--self:add_fatigue_points(fatigue_type, attacking_unit, blocking_unit, fatigue_point_costs_multiplier, is_timed_block)
 			Unit.animation_event(unit, "parry_hit_reaction")
 		end
 

--- a/scripts/mods/TourneyBalance/performance/performance_logging.lua
+++ b/scripts/mods/TourneyBalance/performance/performance_logging.lua
@@ -95,18 +95,24 @@ end
 -- figure out if Deathwish or any Onslaught Mod is turned on (credits to prismism)
 -- added difficulty system for mods like Linesman and also theoretically Dense
 local function is_mod_mutator_enabled(mod_name, mutator_name, difficulty_level)
+
+    -- failsave in case the players doesnt have a mutator mod installed
+    if not get_mod(mod_name) then
+        return false
+    end
+
     local other_mod = get_mod(mod_name)
     local mod_is_enabled = false
     local mutator_is_enabled = false
     local mod_difficulty_level = false
 
     if other_mod then
-      local mutator = other_mod:persistent_table(mutator_name)
-      mod_is_enabled = other_mod:is_enabled()
-      mutator_is_enabled = mutator.active
-      if other_mod.difficulty_level == difficulty_level then
-        mod_difficulty_level = true
-      end
+        local mutator = other_mod:persistent_table(mutator_name)
+        mod_is_enabled = other_mod:is_enabled()
+        mutator_is_enabled = mutator.active
+        if other_mod.difficulty_level == difficulty_level then
+            mod_difficulty_level = true
+        end
     end
     if other_mod.difficulty_level then
         return mod_is_enabled and mutator_is_enabled and mod_difficulty_level


### PR DESCRIPTION
- Fixed an error that causes the performance meassurement to not work when the player is not using some onslaught mutator mods
- Fixed an issue with timed blocks that could cause very large console logs of the host