### PR TITLE
v32.0

### DIFF
--- a/itemV2.cfg
+++ b/itemV2.cfg
@@ -11,6 +11,13 @@ The original intention of Tourney Balance is to be the base line for the various
 
 [b][url=https://docs.google.com/document/d/1AKHfd_0QGPtYnNOiO7IuOf5NSEqDbwN2755Ogowu364/edit?usp=sharing]The full documentation of all the mods changes can be found here.[/url][/b]
 
+Aside of the Balancing features, the mod also incoperates various tools used for events and basic QOL features.
+[b]Mod Checker[/b] will display prohibited mods in usage by yourself and your teammates on screen
+[b]Performance Logging[/b] will create a detailled log of your computers performance for each game as well as information about the players, map name, won or lost, time of match, difficulty, level completion in percent of the individual players, prohibited mods in use by yourslef, prohibited mods in use by teammates. [url=https://docs.google.com/spreadsheets/d/1EPLVTfaYE0jQ8JMZkDU474kw_UWlGdWlc3j0j451X4c/edit?gid=704716676#gid=704716676]A data sheet for the data,[/url] and [url=https://youtu.be/zR2WcVCUgQk]how to use it[/url] can be found here.
+[b]Disable Bots[/b] will disable bots and remove their portraits.
+[b]Pause[/b] will pause the game.
+[b]Restart[/b] will restart the current game.
+
 [h1]Use[/h1]
 Subscribe to the mod and make sure it is positioned below [url=https://steamcommunity.com/sharedfiles/filedetails/?id=1369573612]Vermintide Mod Framework[/url] in the mod load order.
 

--- a/scripts/mods/TourneyBalance/TourneyBalance.lua
+++ b/scripts/mods/TourneyBalance/TourneyBalance.lua
@@ -64,7 +64,13 @@ mod:dofile("scripts/mods/TourneyBalance/changes/career_changes")
 mod:dofile("scripts/mods/TourneyBalance/changes/SpicyEnemies")
 
 -- Performance Logging System
-mod:dofile("scripts/mods/TourneyBalance/performance/performance_logging")
+mod:dofile("scripts/mods/TourneyBalance/logging_and_qol/performance_logging")
+
+-- Mod Checker
+mod:dofile("scripts/mods/TourneyBalance/logging_and_qol/mod_checker")
+
+-- Basic QOL Features
+mod:dofile("scripts/mods/TourneyBalance/logging_and_qol/basic_qol")
 
 -- on_remove_stack_down
 --[[
@@ -426,8 +432,7 @@ for item_template_name, item_template in pairs(Weapons) do
 end
 
 mod.on_enabled = function (self)
-	mod:echo("Tourney balance enabled")
+	mod:echo(mod:localize("mod_enabled"))
 	updateValues()
-
 	return
 end

--- a/scripts/mods/TourneyBalance/TourneyBalance_data.lua
+++ b/scripts/mods/TourneyBalance/TourneyBalance_data.lua
@@ -1,7 +1,89 @@
 local mod = get_mod("TourneyBalance")
 
 return {
-	name = "TourneyBalance",
+	name = mod:localize("mod_name"),
 	is_togglable = false,
-	description = mod:localize("mod_description")
+	description = mod:localize("mod_description"),
+	options = {
+		widgets = {
+			{
+				setting_id = "tourney_checks",
+				type = "group",
+				sub_widgets = {
+					{
+						setting_id = "tourney_mode",
+						type = "checkbox",
+						title = "tourney_mode_title",
+						tootlip = "tourney_mode_description",
+						default_value = false,
+					},
+					{
+						setting_id = "font_size",
+						type = "numeric",
+						title = "font_size_title",
+						tootlip = "font_size_description",
+						range = {10, 50},
+						default_value = 15,
+					},
+					{
+						setting_id = "position_x",
+						type = "numeric",
+						title = "position_x_title",
+						tootlip = "position_x_description",
+						range = {0, 1690}, -- less than 1920 so it cant be moved out of view
+						default_value = 200,
+					},
+					{
+						setting_id = "position_y",
+						type = "numeric",
+						title = "position_y_title",
+						tootlip = "position_y_description",
+						range = {20, 1080}, -- more than 0 so it cant be moved out of view
+						default_value = 1070,
+					},
+
+				},
+			},
+			{
+				setting_id = "qol",
+				type = "group",
+				sub_widgets = {
+					{
+						type = "checkbox",
+						setting_id = "disable_bots",
+						default_value = true,
+						title = "disable_bots_title",
+						tooltip = "disable_bots_description",
+					},
+					{
+						setting_id = "pause",
+						type = "keybind",
+						keybind_trigger = "pressed",
+						keybind_type = "function_call",
+						function_name = "do_pause",
+						title = "pause_title",
+						tooltip = "pause_description",
+						default_value = {},
+					},
+					{
+						setting_id = "restart",
+						type = "keybind",
+						keybind_trigger = "pressed",
+						keybind_type = "function_call",
+						function_name = "restart_level",
+						title = "restart_title",
+						tooltip = "restart_description",
+						default_value = {},
+					},
+				},
+			},
+			{
+				type = "checkbox",
+				setting_id = "performance_logging",
+				default_value = false,
+				title = "performance_logging_title",
+				tooltip = "performance_logging_description",
+			},
+		}
+	}
 }

--- a/scripts/mods/TourneyBalance/TourneyBalance_localization.lua
+++ b/scripts/mods/TourneyBalance/TourneyBalance_localization.lua
@@ -1,5 +1,403 @@
-return {
+local mod = get_mod("TourneyBalance")
+
+local localization = {
+
+	-- General
+	mod_name = {
+		en = "Tourney Balance",
+		fr = "Équilibrage du Tournoi",
+		de = "Turnierbalance",
+		it = "Bilanciamento del Torneo",
+		pl = "Balans Turnieju",
+		zh = "锦标赛平衡",
+		ru = "Баланс турнира",
+		es = "Equilibrio del Torneo",
+		["br-pt"] = "Equilíbrio do Torneio",
+		ko = "토너먼트 밸런스",
+	},
 	mod_description = {
-		en = "TourneyBalance description"
-	}
+		en = "Tourney Balance Testing is a balance mod for Vermintide 2 high difficulty modded gameplay.",
+		fr = "Tourney Balance Testing est un mod d’équilibrage pour la jouabilité modifiée en difficulté élevée dans Vermintide 2.",
+		de = "Tourney Balance Testing ist ein Balancing-Mod für den modifizierten Spielablauf auf hohem Schwierigkeitsgrad in Vermintide 2.",
+		it = "Tourney Balance Testing è una mod di bilanciamento per il gameplay moddato ad alta difficoltà in Vermintide 2.",
+		pl = "Tourney Balance Testing to mod balansujący wysoką trudność rozgrywki moddowanej w Vermintide 2.",
+		zh = "Tourney Balance Testing 是一个用于 Vermintide 2 高难度模组游戏体验的平衡模组。",
+		ru = "Tourney Balance Testing — это балансный мод для игрового процесса Vermintide 2 с высокой сложностью и модификациями.",
+		es = "Tourney Balance Testing es un mod de equilibrio para el modo de juego modificado de alta dificultad en Vermintide 2.",
+		["br-pt"] = "Tourney Balance Testing é um mod de balanceamento para gameplay modificado de alta dificuldade em Vermintide 2.",
+		ko = "Tourney Balance Testing은 Vermintide 2의 높은 난이도 모드 게임을 위한 밸런스 조정 모드입니다.",
+	},
+	mod_enabled = {
+		en = "[TourneyBalance] Mod Enabled.",
+		fr = "[TourneyBalance] Mod activé.",
+		de = "[TourneyBalance] Mod aktiviert.",
+		it = "[TourneyBalance] Mod abilitato.",
+		pl = "[TourneyBalance] Mod włączony.",
+		zh = "[TourneyBalance] 模组已启用。",
+		ru = "[TourneyBalance] Мод включен.",
+		es = "[TourneyBalance] Mod activado.",
+		["br-pt"] = "[TourneyBalance] Mod ativado.",
+		ko = "[TourneyBalance] 모드 활성화.",
+	},
+
+	-- Tourney Mode Dropdown
+	tourney_checks = {
+		en = "Tourney Mode",
+		fr = "Mode Tournoi",
+		de = "Turniermodus",
+		it = "Modalità Torneo",
+		pl = "Tryb Turniejowy",
+		zh = "锦标赛模式",
+		ru = "Режим турнира",
+		es = "Modo Torneo",
+		["br-pt"] = "Modo Torneio",
+		ko = "토너먼트 모드",
+	},
+	tourney_mode_title = {
+		en = "Mod Checker",
+		fr = "Vérificateur de mod",
+		de = "Mod-Checker",
+		it = "Controllo Mod",
+		pl = "Sprawdzacz modów",
+		zh = "模组检查器",
+		ru = "Проверка модов",
+		es = "Comprobador de mods",
+		["br-pt"] = "Verificador de Mod",
+		ko = "모드 검사기",
+	},
+	tourney_mode_description = {
+		en = "Mod Checker will enable a UI widget that displays if you and your team are using any prohibited mods."
+			.. "\nThis option will be automatically enabled during an event.",
+		fr = "Le Vérificateur de mod activera un widget UI indiquant si vous ou votre équipe utilisez des mods interdits."
+			.. "\nCette option sera activée automatiquement pendant un événement.",
+		de = "Der Mod-Checker aktiviert ein UI‑Widget, das anzeigt, ob du oder dein Team unerlaubte Mods verwendet."
+			.. "\nDiese Option wird während eines Events automatisch aktiviert.",
+		it = "Il Controllo Mod attiverà un widget UI che mostra se tu o il tuo team state usando mod proibiti."
+			.. "\nQuesta opzione verrà attivata automaticamente durante un evento.",
+		pl = "Sprawdzacz modów włączy widżet UI, który pokaże, czy Ty lub Twój zespół używacie niedozwolonych modów."
+			.. "\nTa opcja będzie automatycznie włączana podczas wydarzenia.",
+		zh = "模组检查器将启用一个 UI 小部件，显示你或你的队伍是否使用任何禁止的模组。"
+			.. "\n此选项将在活动期间自动启用。",
+		ru = "Проверка модов включит виджет интерфейса, показывающий, используете ли вы или ваша команда запрещенные моды."
+			.. "\nЭта опция будет автоматически включаться во время мероприятия.",
+		es = "El Comprobador de mods activará un widget en la interfaz que mostrará si tú o tu equipo están usando mods prohibidos."
+			.. "\nEsta opción se activará automáticamente durante un evento.",
+		["br-pt"] = "O Verificador de Mod ativará um widget de interface que mostra se você ou sua equipe estão usando mods proibidos."
+			.. "\nEsta opção será ativada automaticamente durante um evento.",
+		ko = "모드 검사기는 당신 또는 팀이 금지된 모드를 사용하는 경우를 표시하는 UI 위젯을 활성화합니다."
+			.. "\n이 옵션은 이벤트 중 자동으로 활성화됩니다.",
+	},
+	font_size_title = {
+		en = "Font Size",
+		fr = "Taille de police",
+		de = "Schriftgröße",
+		it = "Dimensione font",
+		pl = "Rozmiar czcionki",
+		zh = "字体大小",
+		ru = "Размер шрифта",
+		es = "Tamaño de fuente",
+		["br-pt"] = "Tamanho da fonte",
+		ko = "글꼴 크기",
+	},
+	font_size_description = {
+		en = "Font size of the UI widget displaying the prohibited mods.",
+		fr = "Taille de la police du widget UI affichant les mods interdits.",
+		de = "Schriftgröße des UI‑Widgets, das verbotene Mods anzeigt.",
+		it = "Dimensione del font del widget UI che mostra i mod proibiti.",
+		pl = "Rozmiar czcionki widżetu UI wyświetlającego niedozwolone mody.",
+		zh = "显示禁止模组的 UI 小部件的字体大小。",
+		ru = "Размер шрифта виджета UI, отображающего запрещенные моды.",
+		es = "Tamaño de letra del widget de UI que muestra los mods prohibidos.",
+		["br-pt"] = "Tamanho da fonte do widget de interface que mostra os mods proibidos.",
+		ko = "금지된 모드를 표시하는 UI 위젯의 글꼴 크기입니다.",
+	},
+	position_x_title = {
+		en = "X Position",
+		fr = "Position X",
+		de = "X‑Position",
+		it = "Posizione X",
+		pl = "Pozycja X",
+		zh = "X 位置",
+		ru = "Позиция X",
+		es = "Posición X",
+		["br-pt"] = "Posição X",
+		ko = "X 위치",
+	},
+	position_x_description = {
+		en = "X Position of the UI widget.",
+		fr = "Position X du widget UI.",
+		de = "X‑Position des UI‑Widgets.",
+		it = "Posizione X del widget UI.",
+		pl = "Pozycja X widżetu UI.",
+		zh = "UI 小部件的 X 轴位置。",
+		ru = "Позиция X виджета UI.",
+		es = "Posición X del widget de UI.",
+		["br-pt"] = "Posição X do widget de interface.",
+		ko = "UI 위젯의 X 위치입니다.",
+	},
+	position_y_title = {
+		en = "Y Position",
+		fr = "Position Y",
+		de = "Y‑Position",
+		it = "Posizione Y",
+		pl = "Pozycja Y",
+		zh = "Y 位置",
+		ru = "Позиция Y",
+		es = "Posición Y",
+		["br-pt"] = "Posição Y",
+		ko = "Y 위치",
+	},
+	position_y_description = {
+		en = "Y Position of the UI widget.",
+		fr = "Position Y du widget UI.",
+		de = "Y‑Position des UI‑Widgets.",
+		it = "Posizione Y del widget UI.",
+		pl = "Pozycja Y widżetu UI.",
+		zh = "UI 小部件的 Y 轴位置。",
+		ru = "Позиция Y виджета UI.",
+		es = "Posición Y del widget de UI.",
+		["br-pt"] = "Posição Y do widget de interface.",
+		ko = "UI 위젯의 Y 위치입니다.",
+	},
+
+	-- qol
+	qol = {
+		en = "QOL",
+		fr = "QOL",
+		de = "QOL",
+		it = "QOL",
+		pl = "QOL",
+		zh = "便利性",
+		ru = "Удобство",
+		es = "QOL",
+		["br-pt"] = "QOL",
+		ko = "편의 기능",
+	},
+
+	-- Pause
+	not_server = {
+		en = "[TourneyBalance] You need to be host to pause!",
+		fr = "[TourneyBalance] Vous devez être l’hôte pour mettre en pause !",
+		de = "[TourneyBalance] Du musst Gastgeber sein, um anzuhalten!",
+		it = "[TourneyBalance] Devi essere l’host per mettere in pausa!",
+		pl = "[TourneyBalance] Musisz być gospodarzem, aby wstrzymać!",
+		zh = "[TourneyBalance] 你必须是主持人才可暂停！",
+		ru = "[TourneyBalance] Вы должны быть хостом, чтобы поставить на паузу!",
+		es = "[TourneyBalance] ¡Debes ser el anfitrión para pausar!",
+		["br-pt"] = "[TourneyBalance] Você precisa ser o anfitrião para pausar!",
+		ko = "[TourneyBalance] 일시정지하려면 호스트여야 합니다!",
+	},
+	game_unpaused = {
+		en = "[TourneyBalance] Game unpaused!",
+		fr = "[TourneyBalance] Jeu repris !",
+		de = "[TourneyBalance] Spiel fortgesetzt!",
+		it = "[TourneyBalance] Gioco ripreso!",
+		pl = "[TourneyBalance] Gra wznowiona!",
+		zh = "[TourneyBalance] 游戏已恢复！",
+		ru = "[TourneyBalance] Игра продолжена!",
+		es = "[TourneyBalance] ¡Juego reanudado!",
+		["br-pt"] = "[TourneyBalance] Jogo retomado!",
+		ko = "[TourneyBalance] 게임이 재개되었습니다!",
+	},
+	game_paused = {
+		en = "[TourneyBalance] Game paused!",
+		fr = "[TourneyBalance] Jeu en pause !",
+		de = "[TourneyBalance] Spiel pausiert!",
+		it = "[TourneyBalance] Gioco in pausa!",
+		pl = "[TourneyBalance] Gra wstrzymana!",
+		zh = "[TourneyBalance] 游戏已暂停！",
+		ru = "[TourneyBalance] Игра на паузе!",
+		es = "[TourneyBalance] ¡Juego en pausa!",
+		["br-pt"] = "[TourneyBalance] Jogo em pausa!",
+		ko = "[TourneyBalance] 게임이 일시정지되었습니다!",
+	},
+	pause_command_description = {
+		en = "Pause and unpause the game. Host only.",
+		fr = "Mettre en pause et reprendre le jeu. Réservé à l’hôte.",
+		de = "Spiel pausieren und fortsetzen. Nur Host.",
+		it = "Pausa e ripresa del gioco. Solo host.",
+		pl = "Wstrzymanie i wznowienie gry. Tylko dla gospodarza.",
+		zh = "暂停和恢复游戏。仅限主持人。",
+		ru = "Пауза и продолжение игры. Только для хоста.",
+		es = "Pausar y reanudar el juego. Solo anfitrión.",
+		["br-pt"] = "Pausar e retomar o jogo. Somente para anfitrião.",
+		ko = "게임을 일시정지하거나 재개합니다. 오직 호스트만 가능합니다.",
+	},
+	pause_title = {
+		en = "Pause",
+		fr = "Pause",
+		de = "Pause",
+		it = "Pausa",
+		pl = "Pauza",
+		zh = "暂停",
+		ru = "Пауза",
+		es = "Pausa",
+		["br-pt"] = "Pausa",
+		ko = "일시정지",
+	},
+	pause_description = {
+		en = "Hotkey to pause and unpause the game.",
+		fr = "Touche pour mettre en pause et reprendre le jeu.",
+		de = "Hotkey zum Pausieren und Fortsetzen des Spiels.",
+		it = "Tasto rapido per mettere in pausa e riprendere il gioco.",
+		pl = "Klawisz skrótu do wstrzymywania i wznawiania gry.",
+		zh = "游戏暂停/继续的快捷键。",
+		ru = "Горячая клавиша для паузы и продолжения игры.",
+		es = "Tecla rápida para pausar y reanudar el juego.",
+		["br-pt"] = "Tecla de atalho para pausar e retomar o jogo.",
+		ko = "게임을 일시정지 및 재개의 단축키입니다.",
+	},
+
+	-- Restart
+	restart_in_keep = {
+		en = "[TourneyBalance] You can't restart in the keep.",
+		fr = "[TourneyBalance] Vous ne pouvez pas redémarrer dans le refuge.",
+		de = "[TourneyBalance] Du kannst nicht im Zufluchtsort neu starten.",
+		it = "[TourneyBalance] Non puoi riavviare nel rifugio.",
+		pl = "[TourneyBalance] Nie możesz zrestartować w twierdzy.",
+		zh = "[TourneyBalance] 你无法在据点中重启。",
+		ru = "[TourneyBalance] Вы не можете перезапустить игру в убежище.",
+		es = "[TourneyBalance] No puedes reiniciar en la fortaleza.",
+		["br-pt"] = "[TourneyBalance] Você não pode reiniciar no santuário.",
+		ko = "[TourneyBalance] 요새에서는 재시작할 수 없습니다.",
+	},
+	restart_level_command_description = {
+		en = "Restart the level.",
+		fr = "Redémarrer le niveau.",
+		de = "Level neu starten.",
+		it = "Riavvia il livello.",
+		pl = "Zrestartuj poziom.",
+		zh = "重启关卡。",
+		ru = "Перезапустить уровень.",
+		es = "Reiniciar el nivel.",
+		["br-pt"] = "Reiniciar o nível.",
+		ko = "레벨을 재시작합니다.",
+	},
+	restart_title = {
+		en = "Restart",
+		fr = "Redémarrer",
+		de = "Neustart",
+		it = "Riavvia",
+		pl = "Restart",
+		zh = "重启",
+		ru = "Перезапуск",
+		es = "Reiniciar",
+		["br-pt"] = "Reiniciar",
+		ko = "재시작",
+	},
+	restart_description = {
+		en = "Hotkey to restart the current level.",
+		fr = "Touche rapide pour redémarrer le niveau actuel.",
+		de = "Hotkey zum Neustarten des aktuellen Levels.",
+		it = "Tasto rapido per riavviare il livello corrente.",
+		pl = "Klawisz skrótu do zrestartowania obecnego poziomu.",
+		zh = "重启当前关卡的快捷键。",
+		ru = "Горячая клавиша для перезапуска текущего уровня.",
+		es = "Tecla rápida para reiniciar el nivel actual.",
+		["br-pt"] = "Tecla de atalho para reiniciar o nível atual.",
+		ko = "현재 레벨을 재시작하는 단축키입니다.",
+	},
+
+	-- disable bots
+	disable_bots_title = {
+		en = "Disable Bots",
+		fr = "Désactiver les bots",
+		de = "Bots deaktivieren",
+		it = "Disattiva bot",
+		pl = "Wyłącz boty",
+		zh = "禁用机器人",
+		ru = "Отключить ботов",
+		es = "Desactivar bots",
+		["br-pt"] = "Desativar bots",
+		ko = "봇 비활성화",
+	},
+	disable_bots_description = {
+		en = "Disable Bots in the game.",
+		fr = "Désactive les bots dans le jeu.",
+		de = "Bots im Spiel deaktivieren.",
+		it = "Disabilita i bot nel gioco.",
+		pl = "Wyłącz boty w grze.",
+		zh = "在游戏中禁用机器人。",
+		ru = "Отключить ботов в игре.",
+		es = "Desactiva los bots en el juego.",
+		["br-pt"] = "Desativa os bots no jogo.",
+		ko = "게임 내 봇을 비활성화합니다.",
+	},
+
+	-- Performance Logging
+	performance_logging_title = {
+		en = "Performance Logging",
+		fr = "Journalisation des performances",
+		de = "Leistungsprotokollierung",
+		it = "Registrazione delle prestazioni",
+		pl = "Logowanie wydajności",
+		zh = "性能日志",
+		ru = "Журнал производительности",
+		es = "Registro de rendimiento",
+		["br-pt"] = "Registro de desempenho",
+		ko = "성능 기록",
+	},
+	performance_logging_description = {
+		en = "Tool used to Log the performance of your Computer as well as"
+			.. "\nPlayers, Map, Result, Time, Difficulty, Level Completion, Unapproved Mods, Teammates Unapproved Mods."
+			.. "\nFor more information refer to the mods description in the workshop."
+			.. "\nThis option will be automatically enabled during an event.",
+		fr = "Outil utilisé pour journaliser les performances de votre ordinateur ainsi que"
+			.. "\nLes joueurs, la carte, le résultat, le temps, la difficulté, la complétion du niveau, les mods non approuvés, les mods non approuvés des coéquipiers."
+			.. "\nPour plus d’informations, consultez la description du mod dans l’atelier."
+			.. "\nCette option sera activée automatiquement pendant un événement.",
+		de = "Werkzeug zur Protokollierung der Leistung Ihres Computers sowie"
+			.. "\nSpieler, Karte, Ergebnis, Zeit, Schwierigkeitsgrad, Levelabschluss, nicht genehmigte Mods, nicht genehmigte Mods der Teammitglieder."
+			.. "\nWeitere Informationen finden Sie in der Beschreibung des Mods im Workshop."
+			.. "\nDiese Option wird während eines Events automatisch aktiviert.",
+		it = "Strumento usato per registrare le prestazioni del tuo computer così come"
+			.. "\nI giocatori, la mappa, il risultato, il tempo, la difficoltà, completamento del livello, mod non approvati, mod non approvati dei compagni di squadra."
+			.. "\nPer ulteriori informazioni, consulta la descrizione del mod nel workshop."
+			.. "\nQuesta opzione verrà attivata automaticamente durante un evento.",
+		pl = "Narzędzie do rejestrowania wydajności Twojego komputera, jak również"
+			.. "\nGraczy, mapy, wyniku, czasu, trudności, ukończenia poziomu, niezatwierdzonych modów, niezatwierdzonych modów współgraczy."
+			.. "\nPo więcej informacji zajrzyj do opisu moda na warsztacie."
+			.. "\nTa opcja będzie automatycznie włączana podczas wydarzenia.",
+		zh = "用于记录您电脑性能以及"
+			.. "\n玩家、地图、结果、时间、难度、关卡完成、未批准模组、队友未批准模组的工具。"
+			.. "\n更多信息请参考工作坊中的模组描述。"
+			.. "\n此选项将在活动期间自动启用。",
+		ru = "Инструмент для ведения журнала производительности вашего компьютера, а также"
+			.. "\nИгроков, карты, результата, времени, сложности, прохождения уровня, не одобренных модов, не одобренных модов товарищей по команде."
+			.. "\nДля получения дополнительной информации обратитесь к описанию мода в мастерской."
+			.. "\nЭта опция будет автоматически включаться во время мероприятия.",
+		es = "Herramienta usada para registrar el rendimiento de tu ordenador así como"
+			.. "\nJugadores, Mapa, Resultado, Tiempo, Dificultad, Finalización del nivel, Mods no aprobados, Mods no aprobados de compañeros."
+			.. "\nPara más información consulta la descripción del mod en el taller."
+			.. "\nEsta opción se activará automáticamente durante un evento.",
+		["br-pt"] = "Ferramenta usada para registrar o desempenho do seu computador bem como"
+			.. "\nJogadores, Mapa, Resultado, Tempo, Dificuldade, Conclusão do nível, Mods não aprovados, Mods não aprovados dos colegas de equipe."
+			.. "\nPara mais informações, consulte a descrição do mod na oficina."
+			.. "\nEsta opção será ativada automaticamente durante um evento.",
+		ko = "컴퓨터의 성능은 물론"
+			.. "\n플레이어, 지도, 결과, 시간, 난이도, 레벨 완성도, 승인되지 않은 모드, 팀원이 승인하지 않은 모드의 로그를 기록하는 도구입니다."
+			.. "\n자세한 내용은 워크숍의 모드 설명을 참조하세요."
+			.. "\n이 옵션은 이벤트 중 자동으로 활성화됩니다.",
+	},
 }
+
+-- check for korean
+local is_korean = false
+if Localize("holy_hand_grenade") == "모그림의 폭탄" then
+    is_korean = true
+end
+-- overwrite the entire loca table with the korean translation
+if is_korean then
+    local language_id = Application.user_setting("language_id")
+    for k1, v1 in pairs(localization) do
+        for k2, v2 in pairs(v1) do
+            if k2 == language_id then
+                if localization[k1]["ko"] then
+                    localization[k1][k2] = localization[k1]["ko"]
+                end
+            end
+        end
+    end
+end
+
+return localization

--- a/scripts/mods/TourneyBalance/changes/talent_changes.lua
+++ b/scripts/mods/TourneyBalance/changes/talent_changes.lua
@@ -726,10 +726,37 @@ mod:modify_talent("dr_ranger", 5, 2, {
 	},
 })
 
-mod:modify_talent_buff_template("dwarf_ranger", "bardin_ranger_ability_free_grenade_buff", {
-	duration = 10,
-    refresh_durations = true
+
+
+
+-- level 30
+-- Parting Gift
+-- mod:modify_talent_buff_template("dwarf_ranger", "bardin_ranger_ability_free_grenade_buff", {
+-- 	duration = 10,
+--     refresh_durations = true
+-- })
+mod:add_talent_buff_template("dwarf_ranger", "dwarf_ranger_less_burn_on_after_ult_buff", {
+    icon = "bardin_ranger_passive_spawn_healing_draught",
+    stat_buff = "increased_burn_dot_damage",
+    multiplier = -0.52,
+	max_stacks = 1,
+    refresh_durations = true,
+    duration = 18
 })
+mod:add_talent_buff_template("dwarf_ranger", "dwarf_ranger_less_burn_on_after_ult", {
+    buff_func = "add_buff",
+    buff_to_add = "dwarf_ranger_less_burn_on_after_ult_buff",
+    event = "on_ability_cooldown_started"
+})
+mod:modify_talent("dr_ranger", 6, 3, {
+    buffs = {
+        --"bardin_ranger_ability_free_grenade_buff",
+        "dwarf_ranger_less_burn_on_after_ult"
+    }
+})
+mod:add_text("bardin_ranger_ability_free_grenade_desc", "During Disengage Bardin's bomb throw will not be consumed. Only applicable to one bomb. DOT damage is reduced.")
+
+
 
 --[[
 
@@ -1057,31 +1084,6 @@ mod:add_text("gs_bardin_slayer_push_on_dodge_desc", "Effective dodges pushes nea
 -- level 20
 -- Impatience - added unlisted dodge range modifier
 mod:add_text("bardin_slayer_passive_movement_speed_desc", "Each stack of Trophy Hunter increases movement speed by 10.0%% and dodge range by 5.0%%.")
-
--- level 30
--- Parting Gift
-mod:add_talent_buff_template("dwarf_ranger", "dwarf_ranger_less_burn_on_after_ult_buff", {
-    icon = "bardin_ranger_passive_spawn_healing_draught",
-    stat_buff = "increased_burn_dot_damage",
-    multiplier = -0.52,
-	max_stacks = 1,
-    refresh_durations = true,
-    duration = 15
-})
-mod:add_talent_buff_template("dwarf_ranger", "dwarf_ranger_less_burn_on_after_ult", {
-    buff_func = "add_buff",
-    buff_to_add = "dwarf_ranger_less_burn_on_after_ult_buff",
-    event = "on_ability_cooldown_started"
-})
-mod:modify_talent("dr_ranger", 6, 3, {
-    buffs = {
-        "bardin_ranger_ability_free_grenade_buff",
-        "dwarf_ranger_less_burn_on_after_ult"
-    }
-})
-mod:add_text("bardin_ranger_ability_free_grenade_desc", "During Disengage Bardin's bomb throw will not be consumed. Only applicable to one bomb. DOT damage is reduced.")
-
-
 
 --[[
 
@@ -1854,6 +1856,10 @@ end)
 	Battle Wizard Talents
 
 ]]
+
+-- Level 10
+
+-- Famished Flames
 mod:modify_talent_buff_template("bright_wizard", "sienna_adept_increased_burn_damage", {
     multiplier = 1.5, -- 1,
 })
@@ -1862,6 +1868,22 @@ mod:modify_talent_buff_template("bright_wizard", "sienna_adept_reduced_non_burn_
 })
 mod:add_text("sienna_adept_increased_burn_damage_reduced_non_burn_damage_desc", "Burning damage over time is increased by 150.0%%. All non-burn damage is reduced by 30.0%%.")
 
+
+-- Lingering Flames
+mod:add_talent_buff_template("bright_wizard", "battle_wizard_lingering_reduced_dot_damage", {
+    stat_buff = "increased_burn_dot_damage",
+    multiplier = -0.5,
+})
+
+mod:modify_talent("bw_adept", 2, 3, {
+    buffs = {
+        "battle_wizard_lingering_reduced_dot_damage"
+    },
+    description = "tb_sienna_adept_infinite_burn_desc",
+    description_values = {},
+})
+mod:add_text("tb_sienna_adept_infinite_burn_desc", "Sienna's burning effects now last until the affected enemy dies. Burning effects do not stack and deal 50% reduced damage.")
+--[[
 InfiniteBurnDotLookup = InfiniteBurnDotLookup or {}
 local buff_perk_names = require("scripts/unit_extensions/default_player_unit/buffs/settings/buff_perk_names")
 local buff_templates = BuffTemplates
@@ -1888,7 +1910,14 @@ for template_name, template in pairs(buff_templates) do
 		end
 	end
 end
+]]
 
+
+-- Level 25
+
+-- Soot Shield
+-- Official: Igniting an enemy reduces damage taken by 8.0% for 5 seconds. Stacks up to 3 times.
+-- TB: Igniting an enemy reduces damage taken by 5%% for 5 seconds. Stacks up to 4 times.
 mod:modify_talent_buff_template("bright_wizard", "sienna_adept_damage_reduction_on_ignited_enemy_buff", {
     multiplier = -0.05, -- -0.1,
 	max_stacks = 4
@@ -1904,6 +1933,9 @@ mod:modify_talent("bw_adept", 5, 1, {
 })
 mod:add_text("rebaltourn_sienna_adept_damage_reduction_on_ignited_enemy_desc", "Igniting an enemy reduces damage taken by 5%% for 5 seconds. Stacks up to 4 times.")
 
+-- Fires from Ash
+-- Official: Killing a burning enemy reduces the cooldown of Fire Walk by 3%. 0.5 second cooldown.
+-- TB: Killing a burning enemy reduces the cooldown of Fire Walk by 2%. 0.5 second cooldown.
 mod:modify_talent_buff_template("bright_wizard", "sienna_adept_cooldown_reduction_on_burning_enemy_killed", {
     cooldown_reduction = 0.02 --0.03
 })
@@ -1912,12 +1944,21 @@ mod:modify_talent("bw_adept", 5, 2, {
     description_values = {
         {
             value_type = "percent",
-            value = 0.02 --BuffTemplates.sienna_adept_cooldown_reduction_on_burning_enemy_killed.cooldown_reduction
+            value = 0.02
         }
     },
 })
 mod:add_text("rebaltourn_sienna_adept_cooldown_reduction_on_burning_enemy_killed_desc", "Killing a burning enemy reduces the cooldown of Fire Walk by 2%%. 0.5 second cooldown.")
 
+-- Level 30
+
+-- Kaboom!
+-- Official: Fire Walk explosion radius and burn damage increased. No longer leaves a burning trail.
+-- TB: Fire Walk explosion radius and burn damage increased. No longer leaves a burning trail. Cooldown of Fire Walk reduced by 20%.
+mod:add_talent_buff_template("bright_wizard", "sienna_adept_activated_ability_explosion_buff", {
+    stat_buff = "activated_cooldown",
+	multiplier = -0.2
+})
 mod:modify_talent("bw_adept", 6, 2, {
     description = "rebaltourn_sienna_adept_activated_ability_explosion_desc",
 	buffs = {
@@ -1926,10 +1967,6 @@ mod:modify_talent("bw_adept", 6, 2, {
 })
 mod:add_text("rebaltourn_sienna_adept_activated_ability_explosion_desc", "Fire Walk explosion radius and burn damage increased. No longer leaves a burning trail. Cooldown of Fire Walk reduced by 20%.")
 
-mod:add_talent_buff_template("bright_wizard", "sienna_adept_activated_ability_explosion_buff", {
-    stat_buff = "activated_cooldown",
-	multiplier = -0.2
-})
 
 --[[
 
@@ -2254,21 +2291,3 @@ mod:add_proc_function("reduce_activated_ability_cooldown", function (owner_unit,
 		end
 	end
 end)
-
--- Fix Stacking bug for lingering flames with Firebombs
---[[ -- In theory fixed by FS last update
-mod:hook_origin(StackingBuffFunctions, "fire_grenade_dot_add", function (unit, sub_buff_template, current_num_stacks, buff_extension, new_buff_params)
-	local should_add_buff = current_num_stacks < 1      -- should_add_buff = true    idk why changing this works
-	local breed = AiUtils.unit_breed(unit)
-	local talent_extension = ScriptUnit.extension(owner_unit, "talent_system")
-	
-	if breed and breed.is_player then
-	local mechanism_name = Managers.mechanism:current_mechanism_name()
-	
-	if mechanism_name == "versus" then
-	should_add_buff = current_num_stacks < (sub_buff_template.max_player_stacks_in_versus or math.huge)
-	end
-	end
-	
-	return should_add_buff
-end)]]

--- a/scripts/mods/TourneyBalance/changes/thp_stagger_changes.lua
+++ b/scripts/mods/TourneyBalance/changes/thp_stagger_changes.lua
@@ -665,7 +665,7 @@ mod:add_proc_function("rebaltourn_heal_finesse_damage_on_melee", function (owner
 	end
 
 	local heal_amount_crit = 2 -- 6.2 2THP (Previously 1.5THP in TB)
-	local heal_amount_hs = 4 -- 6.2 4THP (Previously 3THP in TB)
+	local heal_amount_crit_hs = 4 -- 6.2 4THP (Previously 3THP in TB)
 	local heal_amount_default = 0.5 -- 6.2 0.5THP newly added to gain THP even when not criting nor hsing
 	local has_procced = buff.has_procced
 	local hit_unit = params[1]
@@ -681,19 +681,16 @@ mod:add_proc_function("rebaltourn_heal_finesse_damage_on_melee", function (owner
 	end
 
 	if ALIVE[owner_unit] and breed and (attack_type == "light_attack" or attack_type == "heavy_attack") and not has_procced then
-		if hit_zone_name == "head" or hit_zone_name == "neck" or hit_zone_name == "weakspot" then
+		if hit_zone_name == "head" or hit_zone_name == "neck" or hit_zone_name == "weakspot" and critical_hit then
+			DamageUtils.heal_network(owner_unit, owner_unit, heal_amount_crit_hs, "heal_from_proc")
 			buff.has_procced = true
 
-			DamageUtils.heal_network(owner_unit, owner_unit, heal_amount_hs, "heal_from_proc")
-
-		elseif critical_hit then
+		elseif critical_hit or hit_zone_name == "head" or hit_zone_name == "neck" or hit_zone_name == "weakspot" then
 			DamageUtils.heal_network(owner_unit, owner_unit, heal_amount_crit, "heal_from_proc")
-
 			buff.has_procced = true
 
 		else
 			DamageUtils.heal_network(owner_unit, owner_unit, heal_amount_default, "heal_from_proc")
-
 			buff.has_procced = true
 		end
 	end

--- a/scripts/mods/TourneyBalance/changes/weapon_changes.lua
+++ b/scripts/mods/TourneyBalance/changes/weapon_changes.lua
@@ -207,6 +207,10 @@ DamageProfileTemplates.dr_deus_01_glance.default_target.boost_curve_type = "tank
 DamageProfileTemplates.dr_deus_01.default_target.boost_curve_coefficient = 0.5
 
 -- Masterwork Pistol Nerf
+local shotgun_dropoff_ranges = {
+	dropoff_end = 15,
+	dropoff_start = 8,
+}
 Weapons.heavy_steam_pistol_template_1.actions.action_one.default.impact_data.damage_profile = "masterwork_pistol_shot"
 Weapons.heavy_steam_pistol_template_1.actions.action_one.shoot.impact_data.damage_profile = "masterwork_pistol_shot"
 Weapons.heavy_steam_pistol_template_1.actions.action_one.fast_shot.impact_data.damage_profile = "masterwork_pistol_shot"
@@ -286,7 +290,7 @@ NewDamageProfileTemplates.masterwork_pistol_shot = {
 			attack = 0.5,
 			impact = 0.5,
 		},
-		range_modifier_settings = shotgun_dropoff_ranges,
+		range_modifier_settings = shotgun_dropoff_ranges
 	},
 }
 

--- a/scripts/mods/TourneyBalance/logging_and_qol/basic_qol.lua
+++ b/scripts/mods/TourneyBalance/logging_and_qol/basic_qol.lua
@@ -1,0 +1,67 @@
+local mod = get_mod("TourneyBalance")
+
+--[[
+
+    Basic QOL features to remove the necessity of unreliable and a multitude of other mods
+    Code snippets originally made by PropJoe in the mods Helpers and TrueSoloQOL
+
+    Janoti! - 2025-08-07
+
+]]
+
+-- Pause.
+mod.paused = false
+mod.do_pause = function()
+	if not Managers.player.is_server then
+		mod:echo(mod:localize("not_server"))
+		return
+	end
+
+	if mod.paused then
+		Managers.state.debug:set_time_scale(13)
+		mod.paused = false
+		mod:echo(mod:localize("game_unpaused"))
+	else
+		Managers.state.debug:set_time_scale(1)
+		mod.paused = true
+		mod:echo(mod:localize("game_paused"))
+	end
+end
+mod:command("pause", mod:localize("pause_command_description"), function() mod.do_pause() end)
+
+-- Restart
+mod.restart_level = function()
+	mod:pcall(function()
+		if DamageUtils.is_in_inn then
+			mod:echo(mod:localize("restart_in_keep"))
+			return
+		else
+			if Managers.state.game_mode then
+				Managers.state.game_mode:retry_level()
+			end
+		end
+	end)
+end
+mod:command("restart", mod:localize("restart_level_command_description"), function() mod.restart_level() end)
+
+-- Disable the bots.
+mod:hook(GameModeAdventure, "_handle_bots",
+function(func, self, ...)
+	local original_cap_num_bots = script_data.cap_num_bots
+
+	if mod:get("disable_bots") then
+		script_data.cap_num_bots = 0
+	end
+
+	func(self, ...)
+
+	script_data.cap_num_bots = original_cap_num_bots
+end)
+-- Prevent a crash with disabled bots.
+mod:hook(AdventureSpawning, "force_update_spawn_positions", function(func, ...)
+	if not mod:get("disable_bots") then
+		return func(...)
+	end
+
+	pcall(func, ...)
+end)

--- a/scripts/mods/TourneyBalance/logging_and_qol/mod_checker.lua
+++ b/scripts/mods/TourneyBalance/logging_and_qol/mod_checker.lua
@@ -1,0 +1,474 @@
+--[[
+    
+    ModChecker is checking what mods are currently installed by the player and their team, cross references that information with
+    a dedicated table which notes which mods are actually allowed to be used and displays the once missing from that list
+    in an UI window on screen. Additionally it shares the checked information with the rest of the team displaying their status on screen as well.
+
+    2025-07-31 - Janoti!
+
+]]
+
+local mod = get_mod("TourneyBalance")
+
+-- Mod Tables
+-- Subject to change
+local allowed_mods_id = {
+
+--Required
+    "2545022878", --TourneyBalance
+    "1835393505", --Cata 3 & Deathwish
+    "2170475262", --Beastmen Loader
+    "2456507597", --No Beastmen
+    "3041453243", --Linesman Onslaught & Daredevil
+    --"1384087820", --True solo qol tweaks (Not needed anymore)
+
+    --"1619024877", --Onslaught
+    --"2179403386", --OnslaughtPlus
+    --"2559718905", --DutchSpice
+    --"1694820325", --A Quiet Drink
+
+--Sanctioned
+    "1369573612", --VMF, Vermintide Mod Framework
+    "1374248490", --penlight lua libraries
+    "1389872347", --Simple Ui (this mod exist twice for some reason and has two names)
+    "1467751760", --HideBuffs, Ui Tweaks
+    "1397265260", --Numeric Ui
+    "1460327284", --BossKillTimer
+    "1384066089", --Neuter Ult Effects
+    "1431393962", --Bestiary
+    "1498992606", --Countries in Lobby Browser
+    "1421155919", --Mission timer
+    "1487862316", --Reroll Improvements
+    "1464907434", --Armory
+    "1502859403", --Notice Key Pickup
+    "1445717962", --Loadout Manager
+    "1402971136", --Needii
+    "1495937978", --Host Quick Play Games
+    "1569650837", --Crosshairs Fix
+    "1395453301", --Skip Intro
+    "2699340287", --Korean Chat
+    "1388911015", --Chat Block
+    "1652856346", --Dodge Count UI
+    "1467945840", --Blood for the blood god
+    "1593460250", --Crosshair Kill Confirmation
+    "1459917022", --Parry Indicator
+    "1448714756", --No Wobble
+    "1383433646", --Persistent Ammo Counter
+    "2038263753", --Remove Hanged Corpses
+    "1384094638", --Crosshair Customization
+    "1383452616", --Killfeed Tweaks
+    "1623948024", --Hi-Def UI Scaling
+    "1516618647", --Friendly Fire Indicator
+    "1498189723", --Customizable Zoom Sensitivity
+    "1504702573", --Streaming Info
+
+--Allowed
+    "1422758813", --More Items Library
+    "1425249043", --Give Weapon
+    "1391114686", --Skip Cutscenes
+    "3370372364", --GiveWeaponFix
+    "1687843693", --SaveWeapon
+    "2824452077", --Give Weapon Supplement - Remove CW Traits
+    "1840873216", --Casual Mode
+    "2820987626", --Give Weapon zh support
+    "3368543012", --Neuter Ult Effects (TEMP)
+    "3366928597", --UI Tweaks Temp
+    "2826469917", --UI Tweaks (zh)
+    "2477335429", --Restart Level
+    "1769554507", --Accessibility Captions
+    "3008293345", --Accessibility Captions 2.0
+    "1609917710", --More Corpses
+    "1405221659", --Less Annoying Friendly Fire
+    "2490345007", --More Skins
+    "1391113873", --More Hats
+    "1423536193", --Give all Hats, Skins, and Paintings
+    "1584145468", --No Overcharge Damage Indicator
+    "2134585757", --Choose Grail Knight Quests
+    "2827932341", --Life's Hard Everywhere
+    "2493528647", --SlaughterHouse
+    "2990935500", --SnowyEnemyRemoval
+    "2955881987", --Set Garbage
+    "2827840248", --Ph. Indicator
+    "2525452894", --Vermintide Analytics
+    "3216778139", --Disable Fog (Replacement for TrueSoloQOL)
+    "1498748049", --Colorful Unique Weapons (Version 2.something)
+    "2760973758", --Headshot Counter
+    "2503071508", --DisplayTeamName
+    "2385964757", --DPS Meter
+    "1545823051", --Duct Tape Mod
+    "2418326943", --Fix Restart Sound Bug
+    "2134634186", --Choose Weather
+    "2174425628", --Hat Control
+    "2993715887", --Maps for mission selection
+    "2801810157", --Clock Time (Specifically when players are playing outside of the normal tourney time)
+
+--Balance Mods
+    --"2503948895", --ClassBalance
+    --"3302053065", --Linesman Balance
+    --"3141239720", --Kite together
+    --"2705276978", --Core's Big Rebalance
+    --"2874461307", --Live Remasted
+
+--Goober / Linesman Event exclusive
+    --"2688241862", --Sons of Sigmar - Gooby only
+    --"1393694530", --Spawn Tweaks - Gooby only
+    --"1460857124", --Chat Wheel
+    "2803255292", --Specials Sound Cues Fix
+    "2824402636", --Less Corpses
+    "3214214805", --Straight to Keep and Quit Game
+    "2866794030", --Waypoints
+    "3082495950", --NoSmokeBountyHunter&EnsorcelledReaperNoVFX
+    "2649047582", --Remove Ability Bobbing
+    "1642545164", --Disable Friendly Fire Dialogue
+
+--Debug
+    --"3348952854", --TourneyBalanceBeta
+    --"3153107118", --lan Lobby
+}
+
+local active_mods = {}
+local prohibited_mods = {}
+
+-- Tourney Time
+local is_tourney_time = false
+local tourney_time = {
+    start_time = {
+        year = 2025,
+        month = 8,
+        day = 21,
+        hour = 12,
+        min = 0,
+        sec = 0
+    },
+    end_time = {
+        year = 2025,
+        month = 9,
+        day = 1,
+        hour = 12,
+        min = 0,
+        sec = 0
+    },
+}
+
+-- Title Text
+local approved_mods = {
+    "Tourney Approved!",
+    "Tourney Approved!",
+    "Tourney Approved!",
+    "Tourney Approved!",
+}
+local prohibited_mods_detect = {
+    "UNAPPROVED MODS DETECTED!",
+    "UNAPPROVED MODS DETECTED!",
+    "UNAPPROVED MODS DETECTED!",
+    "UNAPPROVED MODS DETECTED!",
+}
+local teammates_have_prohibited_mods = {
+    "TEAMMATES USE UNAPPROVED MODS!",
+    "TEAMMATES USE UNAPPROVED MODS!",
+    "TEAMMATES USE UNAPPROVED MODS!",
+    "TEAMMATES USE UNAPPROVED MODS!",
+}
+
+-- Networking
+local send_prohibited_mods = false
+
+-- Data Logging
+mod.unapproved_mods_data = " "
+mod.teammates_unapproved_mods_data = "false"
+mod.is_tourney_time_performance_logging = is_tourney_time
+
+--[[
+
+░██████╗██╗░░██╗░█████╗░░██╗░░░░░░░██╗  ████████╗███████╗██╗░░██╗████████╗
+██╔════╝██║░░██║██╔══██╗░██║░░██╗░░██║  ╚══██╔══╝██╔════╝╚██╗██╔╝╚══██╔══╝
+╚█████╗░███████║██║░░██║░╚██╗████╗██╔╝  ░░░██║░░░█████╗░░░╚███╔╝░░░░██║░░░
+░╚═══██╗██╔══██║██║░░██║░░████╔═████║░  ░░░██║░░░██╔══╝░░░██╔██╗░░░░██║░░░
+██████╔╝██║░░██║╚█████╔╝░░╚██╔╝░╚██╔╝░  ░░░██║░░░███████╗██╔╝╚██╗░░░██║░░░
+╚═════╝░╚═╝░░╚═╝░╚════╝░░░░╚═╝░░░╚═╝░░  ░░░╚═╝░░░╚══════╝╚═╝░░╚═╝░░░╚═╝░░░
+]]
+
+local font_name = "arial"
+local font_material = "materials/fonts/" .. font_name
+local white_color = Colors.color_definitions.white
+local black_color = Colors.color_definitions.black
+local red_color = Colors.color_definitions.red
+
+-- get the current user settings for font size and position of the UI widget
+local get_user_settings = function ()
+    mod.font_size = mod:get("font_size")
+    mod.position = {
+        mod:get("position_x"),
+        mod:get("position_y"),
+    }
+end
+
+-- initialize the renderer to draw the text
+local render_init = function ()
+    local world = Managers.world:world("top_ingame_view")
+    mod.renderer = UIRenderer.create(world, "material", "materials/fonts/gw_fonts")
+end
+
+-- display the text on screen
+local show_text = function ()
+    local renderer = mod.renderer
+    local display_position = table.clone(mod.position)
+
+    if prohibited_mods then
+        for k, v in pairs(prohibited_mods) do
+            local font_size = mod.font_size
+            -- make title bigger than rest
+            if v[1] == v[2] then
+                font_size = font_size * 1.5
+            end
+            display_position[2] = display_position[2] - (font_size + 1)
+            local display_text = v[2]
+            UIRenderer.draw_text(renderer, display_text, font_material, font_size, font_name, display_position, white_color) -- also has retained_id and color_override 
+        end
+    end
+end
+mod:hook_safe(IngameHud, "update", function(self)
+    -- check for visibility of UI
+    if not self._currently_visible_components.EquipmentUI then
+        return
+    end
+    if is_tourney_time or mod:get("tourney_mode") then
+        show_text()
+    end
+end)
+
+
+--[[
+
+░██████╗░███████╗████████╗  ███╗░░░███╗░█████╗░██████╗░░██████╗
+██╔════╝░██╔════╝╚══██╔══╝  ████╗░████║██╔══██╗██╔══██╗██╔════╝
+██║░░██╗░█████╗░░░░░██║░░░  ██╔████╔██║██║░░██║██║░░██║╚█████╗░
+██║░░╚██╗██╔══╝░░░░░██║░░░  ██║╚██╔╝██║██║░░██║██║░░██║░╚═══██╗
+╚██████╔╝███████╗░░░██║░░░  ██║░╚═╝░██║╚█████╔╝██████╔╝██████╔╝
+░╚═════╝░╚══════╝░░░╚═╝░░░  ╚═╝░░░░░╚═╝░╚════╝░╚═════╝░╚═════╝░
+
+]]
+
+-- get info about active mods of local player (Active meaning turned on in mod launcher)
+local get_active_mods = function()
+    VMF = get_mod("VMF")
+
+    local all_mods = VMF.mods
+    if not all_mods then
+        return
+    end
+
+    for k, v in pairs(all_mods) do
+        local mod_metatable = getmetatable(all_mods[k]._data)
+        local active_mod = {
+            mod_metatable.__index.is_enabled, -- true of false if enabled in VMF settings in game
+            mod_metatable.__index.readable_name, -- localized ingame Name
+            k, -- Code name
+            mod_metatable.__index.workshop_id, -- ID
+        }
+        table.insert(active_mods, active_mod)
+    end
+
+end
+-- cross reference and print function of total mods that are not allowed
+local check_mods = function ()
+    if not active_mods then
+        return
+    end
+
+    local prohibited_mods_check = {}
+
+    for _, v1 in pairs(active_mods) do
+        for k2, v2 in pairs(allowed_mods_id) do
+            if v1[4] == v2 then
+                break
+            elseif v1[4] ~= v2 and k2 == #allowed_mods_id then
+                table.insert(prohibited_mods_check, v1)
+            end
+        end
+    end
+
+    -- prevent duplicates to go into the list
+    for k1, v1 in pairs(prohibited_mods_check) do
+        if prohibited_mods[1] then
+            for k2, v2 in pairs(prohibited_mods) do
+                if v1[4] == v2[4] then
+                    break
+                elseif v1[4] ~= v2[4] and k2 == #prohibited_mods then
+                    table.insert(prohibited_mods, v1)
+                end
+            end
+        else
+            table.insert(prohibited_mods, v1)
+        end
+    end
+
+end
+
+-- Performance Logging Data
+-- write all prohibited mods in usage in variable to be saved in performance data in the console log
+local write_logging_mods_data = function ()
+    if #prohibited_mods == 1 then
+        mod.unapproved_mods_data = "None"
+        return
+    end
+
+    for _, v in pairs(prohibited_mods) do
+        mod.unapproved_mods_data = mod.unapproved_mods_data .. " | " .. v[2]
+    end
+end
+-- write if prohibited mods are used by teammates in variable to be saved in performance data in the console log
+local write_logging_mods_data_teammates = function ()
+    mod.teammates_unapproved_mods_data = tostring(send_prohibited_mods)
+end
+
+-- Add the title to display that the local player uses or not uses prohibited mods
+local add_title_display_text = function ()
+    if #prohibited_mods == 0 then
+        table.remove(prohibited_mods, 1)
+        table.insert(prohibited_mods, 1, approved_mods)
+    elseif #prohibited_mods > 0 then
+        if prohibited_mods[1][1] == prohibited_mods_detect[1] then
+            return
+        end
+        if prohibited_mods[1][1] == approved_mods[1] then
+            return
+        end
+        table.insert(prohibited_mods, 1, prohibited_mods_detect)
+    end
+end
+-- Remove the Title about teammates using prohibited mods
+local remove_teammates_warning = function()
+    if send_prohibited_mods == true then
+        if prohibited_mods[2] == teammates_have_prohibited_mods then
+            table.remove(prohibited_mods, 2)
+            write_logging_mods_data_teammates()
+        end
+    end
+end
+
+
+
+--[[
+
+███╗░░██╗███████╗████████╗░██╗░░░░░░░██╗░█████╗░██████╗░██╗░░██╗██╗███╗░░██╗░██████╗░
+████╗░██║██╔════╝╚══██╔══╝░██║░░██╗░░██║██╔══██╗██╔══██╗██║░██╔╝██║████╗░██║██╔════╝░
+██╔██╗██║█████╗░░░░░██║░░░░╚██╗████╗██╔╝██║░░██║██████╔╝█████═╝░██║██╔██╗██║██║░░██╗░
+██║╚████║██╔══╝░░░░░██║░░░░░████╔═████║░██║░░██║██╔══██╗██╔═██╗░██║██║╚████║██║░░╚██╗
+██║░╚███║███████╗░░░██║░░░░░╚██╔╝░╚██╔╝░╚█████╔╝██║░░██║██║░╚██╗██║██║░╚███║╚██████╔╝
+╚═╝░░╚══╝╚══════╝░░░╚═╝░░░░░░╚═╝░░░╚═╝░░░╚════╝░╚═╝░░╚═╝╚═╝░░╚═╝╚═╝╚═╝░░╚══╝░╚═════╝░
+]]
+
+-- networking system in which the info about active mods is shared among all players
+local settings_sync_package_id = "tourney_check"
+
+-- Compare Tables --TODO (add functionality to share the entire mod list instead of a bool)
+local function compare_mod_list(received_mod_list)
+    -- compare the incoming table and the one already here
+    -- combine the two different tables
+
+    if not received_mod_list then
+        return
+    end
+
+    send_prohibited_mods = received_mod_list
+    write_logging_mods_data_teammates()
+
+    -- comparing the lists
+    --for k, v in pairs(received_mod_list) do
+    --    mod.send[k] = v
+    --end
+
+    -- incoperate list into UI
+    table.insert(prohibited_mods, 2, teammates_have_prohibited_mods)
+end
+
+-- Send Mods
+local function sync_mods()
+	mod:network_send(
+		settings_sync_package_id,
+		"others",
+        send_prohibited_mods
+	)
+end
+
+-- Receive Mods
+mod:network_register(settings_sync_package_id, function(sender, mod_table)
+    compare_mod_list(mod_table)
+end)
+
+-- New Player
+mod.on_user_joined = function(player)
+	sync_mods()
+end
+-- Player Left
+mod.on_user_left = function(player)
+	sync_mods()
+    remove_teammates_warning()
+end
+
+
+--[[
+
+████████╗░█████╗░██╗░░░██╗██████╗░███╗░░██╗███████╗██╗░░░██╗  ████████╗██╗███╗░░░███╗███████╗
+╚══██╔══╝██╔══██╗██║░░░██║██╔══██╗████╗░██║██╔════╝╚██╗░██╔╝  ╚══██╔══╝██║████╗░████║██╔════╝
+░░░██║░░░██║░░██║██║░░░██║██████╔╝██╔██╗██║█████╗░░░╚████╔╝░  ░░░██║░░░██║██╔████╔██║█████╗░░
+░░░██║░░░██║░░██║██║░░░██║██╔══██╗██║╚████║██╔══╝░░░░╚██╔╝░░  ░░░██║░░░██║██║╚██╔╝██║██╔══╝░░
+░░░██║░░░╚█████╔╝╚██████╔╝██║░░██║██║░╚███║███████╗░░░██║░░░  ░░░██║░░░██║██║░╚═╝░██║███████╗
+░░░╚═╝░░░░╚════╝░░╚═════╝░╚═╝░░╚═╝╚═╝░░╚══╝╚══════╝░░░╚═╝░░░  ░░░╚═╝░░░╚═╝╚═╝░░░░░╚═╝╚══════╝
+
+]]
+
+-- Check Time
+local start_time = os.time(os.date("!*t", os.time(tourney_time.start_time)))
+local end_time = os.time(os.date("!*t", os.time(tourney_time.end_time)))
+local current_time = os.time(os.date("!*t"))
+local check_tourney_time = function()
+    is_tourney_time = (current_time >= start_time and current_time <= end_time)
+    mod.is_tourney_time_performance_logging = is_tourney_time
+end
+
+
+--[[
+
+██╗░░░░░░█████╗░░█████╗░██████╗░██╗███╗░░██╗░██████╗░
+██║░░░░░██╔══██╗██╔══██╗██╔══██╗██║████╗░██║██╔════╝░
+██║░░░░░██║░░██║███████║██║░░██║██║██╔██╗██║██║░░██╗░
+██║░░░░░██║░░██║██╔══██║██║░░██║██║██║╚████║██║░░╚██╗
+███████╗╚█████╔╝██║░░██║██████╔╝██║██║░╚███║╚██████╔╝
+╚══════╝░╚════╝░╚═╝░░╚═╝╚═════╝░╚═╝╚═╝░░╚══╝░╚═════╝░
+]]
+
+-- Check one after another
+-- enable and disable functionality through checkbox but also function that brute force turns it on when a given time is met (aka tourney time)
+local initiate_mod_checker = function ()
+    render_init()
+    get_user_settings()
+
+    -- Check Time
+    check_tourney_time()
+
+    if is_tourney_time or mod:get("tourney_mode") then
+        get_active_mods()
+        check_mods()
+        write_logging_mods_data()
+        add_title_display_text()
+    end
+end
+mod.on_all_mods_loaded = function()
+    initiate_mod_checker()
+end
+mod.on_setting_changed = function()
+    initiate_mod_checker()
+end
+
+-- Join or Leave Game
+mod.on_game_state_changed_mod_checker = function()
+    initiate_mod_checker()
+    if #prohibited_mods > 1 then
+        send_prohibited_mods = true
+    else
+        send_prohibited_mods = false
+    end
+    remove_teammates_warning()
+end


### PR DESCRIPTION
- Added ModChecker tool that checks for prohibited mods and displays them on screen
- Performance Logging now also saves prohibited mods in their data log
- Added full localization for mod settings
- Added QOL features such as (Disable Bots, Pause, Restart)

- Fixed MWP having no range dropoff damage
- Fixed Crit THP on hs giving too much thp
- Fixed Lingering Flames stacking uncontrollably with firebombs
- Fixed Lingering Flames not being halfed in damage compared to official