### PR TITLE
Fixes the cannon crash in "Return to the Reik"

### DIFF
--- a/scripts/mods/TourneyBalance/changes/thp_stagger_changes.lua
+++ b/scripts/mods/TourneyBalance/changes/thp_stagger_changes.lua
@@ -65,6 +65,20 @@ Breeds.skaven_stormfiend_boss.bloodlust_health = NewBreedTweaks.bloodlust_health
 Breeds.skaven_stormfiend.bloodlust_health = NewBreedTweaks.bloodlust_health.monster
 Breeds.skaven_warpfire_thrower.bloodlust_health = NewBreedTweaks.bloodlust_health.skaven_special
 
+-- Fixes the cannons crashing the game in "Return of the Reik"
+mod:hook(DamageUtils, "stagger_ai", function (func, t, damage_profile, target_index, power_level, target_unit, attacker_unit, hit_zone_name, attack_direction, boost_curve_multiplier, is_critical_strike, blocked, damage_source, source_attacker_unit, optional_predicted_damage)
+	if not attacker_unit then
+		if not POSITION_LOOKUP[target_unit] then
+			return
+		end
+		attacker_unit = target_unit
+	end
+	if not POSITION_LOOKUP[target_unit] and (not target_unit or not Unit.alive(target_unit)) then
+		return
+	end
+	return func(t, damage_profile, target_index, power_level, target_unit, attacker_unit, hit_zone_name, attack_direction, boost_curve_multiplier, is_critical_strike, blocked, damage_source, source_attacker_unit, optional_predicted_damage)
+end)
+
 -- Fixed Vanguard not proccing when you killed an enemy which is staggered
 local dead_units = {}
 local damage_source_procs = {


### PR DESCRIPTION
Fixes an issue where the cannon is cause a crash in "Return to the Reik" due to staggering dead bodies.